### PR TITLE
Add data for modules

### DIFF
--- a/src/getStatsFromCompilation.ts
+++ b/src/getStatsFromCompilation.ts
@@ -1,7 +1,7 @@
-import { Compilation, Module } from 'webpack';
-import { BundleStats, Chunk, ChunkGroup } from './types/BundleStats';
+import { Compilation, Module as RawModule } from 'webpack';
+import { BundleStats, Chunk, ChunkGroup, Module } from './types/BundleStats';
 
-export function getStatsFromCompilation(compilation: Compilation): any {
+export function getStatsFromCompilation(compilation: Compilation): BundleStats {
     return {
         chunkGroups: getChunkGroups(compilation),
         chunks: getChunks(compilation),
@@ -29,15 +29,15 @@ function getChunks(compilation: Compilation): Chunk[] {
     }));
 }
 
-function getModules(compilation: Compilation): any[] {
+function getModules(compilation: Compilation): Module[] {
     return [...compilation.modules].map(m => getModule(m, compilation));
 }
 
-function getModule(m: Module, compilation: Compilation): any {
+function getModule(m: RawModule, compilation: Compilation): Module {
     return {
         moduleType: m.constructor.name,
         readableIdentifier: m.readableIdentifier(compilation.requestShortener),
-        modules: (m as any).modules?.map((m2: any) => getModule(m2, compilation)),
+        modules: (m as any).modules?.map((m2: RawModule) => getModule(m2, compilation)),
         size: m.size(),
     };
 }

--- a/src/getStatsFromCompilation.ts
+++ b/src/getStatsFromCompilation.ts
@@ -1,4 +1,4 @@
-import { Compilation } from 'webpack';
+import { Compilation, Module } from 'webpack';
 import { BundleStats, Chunk, ChunkGroup } from './types/BundleStats';
 
 export function getStatsFromCompilation(compilation: Compilation): any {
@@ -40,16 +40,18 @@ function getChunks(compilation: Compilation): Chunk[] {
 }
 
 function getModules(compilation: Compilation): any[] {
-    return [...compilation.modules].map(m => ({
+    return [...compilation.modules].map(m => getModule(m, compilation));
+}
+
+function getModule(m: Module, compilation: Compilation): any {
+    return {
         moduleType: m.constructor.name,
         readableIdentifier: m.readableIdentifier(compilation.requestShortener),
 
         // TODO: Seems like this is not that interesting, since it can be derived from chunk data,
         // and it doesn't include chuncks where this module is in a concatenated module
         getModuleChunks: compilation.chunkGraph.getModuleChunks(m).map(c => c.id),
-        modules: (m as any).modules?.map((m2: any) =>
-            m2.readableIdentifier(compilation.requestShortener)
-        ),
+        modules: (m as any).modules?.map((m2: any) => getModule(m2, compilation)),
         size: m.size(),
-    }));
+    };
 }

--- a/src/getStatsFromCompilation.ts
+++ b/src/getStatsFromCompilation.ts
@@ -33,6 +33,9 @@ function getChunks(compilation: Compilation): Chunk[] {
         id: c.id || '<null>',
         name: c.name || undefined,
         files: [...c.files],
+        modules: compilation.chunkGraph
+            .getChunkModules(c)
+            .map(m => m.readableIdentifier(compilation.requestShortener)),
     }));
 }
 

--- a/src/getStatsFromCompilation.ts
+++ b/src/getStatsFromCompilation.ts
@@ -43,9 +43,13 @@ function getModules(compilation: Compilation): any[] {
     return [...compilation.modules].map(m => ({
         moduleType: m.constructor.name,
         readableIdentifier: m.readableIdentifier(compilation.requestShortener),
+
+        // TODO: Seems like this is not that interesting, since it can be derived from chunk data,
+        // and it doesn't include chuncks where this module is in a concatenated module
         getModuleChunks: compilation.chunkGraph.getModuleChunks(m).map(c => c.id),
         modules: (m as any).modules?.map((m2: any) =>
             m2.readableIdentifier(compilation.requestShortener)
         ),
+        size: m.size(),
     }));
 }

--- a/src/getStatsFromCompilation.ts
+++ b/src/getStatsFromCompilation.ts
@@ -4,7 +4,6 @@ import { BundleStats, Chunk, ChunkGroup } from './types/BundleStats';
 export function getStatsFromCompilation(compilation: Compilation): any {
     return {
         chunkGroups: getChunkGroups(compilation),
-        namedChunkGroups: getNamedChunkGroups(compilation), // TOOD: Confirm that this is redundant
         chunks: getChunks(compilation),
         modules: getModules(compilation),
     };
@@ -12,15 +11,6 @@ export function getStatsFromCompilation(compilation: Compilation): any {
 
 function getChunkGroups(compilation: Compilation): ChunkGroup[] {
     return compilation.chunkGroups.map(cg => ({
-        id: cg.id,
-        name: cg.name || undefined,
-        children: [...cg.childrenIterable].map(cg2 => cg2.id),
-        chunks: cg.chunks.map(c => c.id!),
-    }));
-}
-
-function getNamedChunkGroups(compilation: Compilation): ChunkGroup[] {
-    return [...compilation.namedChunkGroups.values()].map(cg => ({
         id: cg.id,
         name: cg.name || undefined,
         children: [...cg.childrenIterable].map(cg2 => cg2.id),
@@ -47,10 +37,6 @@ function getModule(m: Module, compilation: Compilation): any {
     return {
         moduleType: m.constructor.name,
         readableIdentifier: m.readableIdentifier(compilation.requestShortener),
-
-        // TODO: Seems like this is not that interesting, since it can be derived from chunk data,
-        // and it doesn't include chuncks where this module is in a concatenated module
-        getModuleChunks: compilation.chunkGraph.getModuleChunks(m).map(c => c.id),
         modules: (m as any).modules?.map((m2: any) => getModule(m2, compilation)),
         size: m.size(),
     };

--- a/src/types/BundleStats.ts
+++ b/src/types/BundleStats.ts
@@ -1,6 +1,7 @@
 export interface BundleStats {
     chunkGroups: ChunkGroup[];
     chunks: Chunk[];
+    modules: Module[];
 }
 
 export interface ChunkGroup {
@@ -16,3 +17,10 @@ export interface Chunk {
 }
 
 export type ChunkId = string | number;
+
+export interface Module {
+    moduleType: string;
+    readableIdentifier: string;
+    modules?: Module[];
+    size: number;
+}


### PR DESCRIPTION
This adds a bunch of data about modules to the output `BundleStats`.