### PR TITLE
Update typing for Chunk

### DIFF
--- a/src/types/BundleStats.ts
+++ b/src/types/BundleStats.ts
@@ -15,6 +15,8 @@ export interface ChunkGroup {
 export interface Chunk {
     id: ChunkId;
     name?: string;
+    files: string[];
+    modules: string[];
 }
 
 export type ChunkId = string | number;


### PR DESCRIPTION
There were a couple properties missing in the `Chunk` type; this adds them.