### PR TITLE
Embed modules within chunks

### DIFF
--- a/src/getStatsFromCompilation.ts
+++ b/src/getStatsFromCompilation.ts
@@ -8,7 +8,6 @@ export function getStatsFromCompilation(compilation: Compilation): BundleStats {
         webpackBundleStatsPluginVersion: version,
         chunkGroups: getChunkGroups(compilation),
         chunks: getChunks(compilation),
-        modules: getModules(compilation),
     };
 }
 
@@ -26,14 +25,8 @@ function getChunks(compilation: Compilation): Chunk[] {
         id: c.id || '<null>',
         name: c.name || undefined,
         files: [...c.files],
-        modules: compilation.chunkGraph
-            .getChunkModules(c)
-            .map(m => m.readableIdentifier(compilation.requestShortener)),
+        modules: compilation.chunkGraph.getChunkModules(c).map(m => getModule(m, compilation)),
     }));
-}
-
-function getModules(compilation: Compilation): Module[] {
-    return [...compilation.modules].map(m => getModule(m, compilation));
 }
 
 function getModule(m: RawModule, compilation: Compilation): Module {

--- a/src/types/BundleStats.ts
+++ b/src/types/BundleStats.ts
@@ -2,7 +2,6 @@ export interface BundleStats {
     webpackBundleStatsPluginVersion: string;
     chunkGroups: ChunkGroup[];
     chunks: Chunk[];
-    modules: Module[];
 }
 
 export interface ChunkGroup {
@@ -16,7 +15,7 @@ export interface Chunk {
     id: ChunkId;
     name?: string;
     files: string[];
-    modules: string[];
+    modules: Module[];
 }
 
 export type ChunkId = string | number;


### PR DESCRIPTION
There are cases where you can have modules with the same `readableIdentifier` but different content.  (I don't think this will happen with source modules, but I've observed with with webpack runtime modules.)  This change embeds the modules within the chunks so that it is clear which instance of each module is associated with which chunk.