### PR TITLE
Include chunk group origins

### DIFF
--- a/src/getStatsFromCompilation.ts
+++ b/src/getStatsFromCompilation.ts
@@ -1,5 +1,5 @@
 import { Compilation, Module as RawModule } from 'webpack';
-import { Asset, BundleStats, Chunk, ChunkGroup, Module } from './types/BundleStats';
+import { Asset, BundleStats, Chunk, ChunkGroup, Module, OriginModule } from './types/BundleStats';
 
 export function getStatsFromCompilation(compilation: Compilation): BundleStats {
     const { version } = require('../package.json');
@@ -30,9 +30,7 @@ function getChunkGroups(compilation: Compilation): ChunkGroup[] {
         chunks: cg.chunks.map(c => c.id!),
         origins: cg.origins.map(origin => ({
             request: origin.request,
-            module:
-                (origin.module && origin.module.readableIdentifier(compilation.requestShortener)) ||
-                undefined,
+            module: getOriginModule(origin.module, compilation),
         })),
     }));
 }
@@ -53,4 +51,14 @@ function getModule(m: RawModule, compilation: Compilation): Module {
         modules: (m as any).modules?.map((m2: RawModule) => getModule(m2, compilation)),
         size: m.size(),
     };
+}
+
+function getOriginModule(m: RawModule, compilation: Compilation): OriginModule | undefined {
+    if (m) {
+        return {
+            readableIdentifier: m.readableIdentifier(compilation.requestShortener),
+        };
+    } else {
+        return undefined;
+    }
 }

--- a/src/getStatsFromCompilation.ts
+++ b/src/getStatsFromCompilation.ts
@@ -28,6 +28,12 @@ function getChunkGroups(compilation: Compilation): ChunkGroup[] {
         name: cg.name || undefined,
         children: [...cg.childrenIterable].map(cg2 => cg2.id),
         chunks: cg.chunks.map(c => c.id!),
+        origins: cg.origins.map(origin => ({
+            request: origin.request,
+            module:
+                (origin.module && origin.module.readableIdentifier(compilation.requestShortener)) ||
+                undefined,
+        })),
     }));
 }
 

--- a/src/types/BundleStats.ts
+++ b/src/types/BundleStats.ts
@@ -15,6 +15,7 @@ export interface ChunkGroup {
     name?: string;
     children: string[];
     chunks: ChunkId[];
+    origins: Origin[];
 }
 
 export interface Chunk {
@@ -31,4 +32,9 @@ export interface Module {
     readableIdentifier: string;
     modules?: Module[];
     size: number;
+}
+
+export interface Origin {
+    request: string;
+    module?: string;
 }

--- a/src/types/BundleStats.ts
+++ b/src/types/BundleStats.ts
@@ -36,5 +36,9 @@ export interface Module {
 
 export interface Origin {
     request: string;
-    module?: string;
+    module?: OriginModule;
+}
+
+export interface OriginModule {
+    readableIdentifier: string;
 }


### PR DESCRIPTION
This includes the `origins` property from `ChunkGroup`.